### PR TITLE
markdown: kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+markdown: kramdown
 collections:
 - albums:
   - output: true


### PR DESCRIPTION
https://help.github.com/articles/page-build-failed-markdown-errors/

> If you are not using kramdown as your Markdown processor, then you must update your Markdown processor to kramdown. GitHub Pages only supports kramdown.