### PR TITLE
Configure baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+baseurl: "."
 markdown: kramdown
 collections:
   albums:


### PR DESCRIPTION
`collector` was missing from the URL on https://ryanve.github.io/collector/

https://jekyllrb.com/docs/configuration/